### PR TITLE
Increase MAX_BLOCK_SIZE to 8192

### DIFF
--- a/tftp/session.py
+++ b/tftp/session.py
@@ -9,7 +9,7 @@ from twisted.internet.defer import maybeDeferred
 from twisted.internet.protocol import DatagramProtocol
 from twisted.python import log
 
-MAX_BLOCK_SIZE = 1400
+MAX_BLOCK_SIZE = 8192
 
 
 class WriteSession(DatagramProtocol):


### PR DESCRIPTION
The current MAX_BLOCK_SIZE only allows files of up to ~87 MB in size.
Considering that a windows winpe ramdisk can grow to about ~270 MB,
it would just fail after block nr 65535. Increasing this constant
will allow clients to negotiate a larget block size and by extension,
speed up transfers (the purpose of this change) and allow a larger file
size (less important, as this is fixed by rollover).

The maximum size of a UDP message is 65507. Increasing the block size
past the maximum allowed MTU, will cause the TCP/IP stack to fragment the
frame. So there is no reason for it to fail if you use these settings in
the same broadcast domain.

It is not mandatory for the client to ask for a block size as large as this. It
is just a higher cap, up to which a client may negotiate.

Preferably, this would be configurable per backend, and not hardcoded
in session.py.
