### PR TITLE
Fix a disconnection and timeout crash.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *~
 /.eggs
 /.tox
-/_trial_temp
+/_trial_temp*
 /bin
 /dist
 /include

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.pyo
 *~
+/.eggs
 /.tox
 /_trial_temp
 /bin
@@ -8,6 +9,8 @@
 /include
 /lib
 /local
+/pip-selfcheck.json
+/share
 /TAGS
 /tags
 dropin.cache

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test: bin/tox
 	@bin/tox
 
 clean:
-	$(RM) -r bin build dist include lib local TAGS tags
+	$(RM) -r bin build dist include lib local share TAGS tags
 	find . -name '*.py[co]' -print0 | xargs -r0 $(RM) -r
 	find . -name '__pycache__' -print0 | xargs -r0 $(RM) -r
 	find . -name '*.egg' -print0 | xargs -r0 $(RM) -r

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test = trial

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,6 @@ setup(
     packages={'tftp'},
     install_requires={"Twisted"},
     description="A Twisted-based TFTP implementation.",
+    setup_requires={"setuptools_trial"},
+    test_suite="tftp",
 )

--- a/tftp/bootstrap.py
+++ b/tftp/bootstrap.py
@@ -1,12 +1,15 @@
 '''
 @author: shylent
 '''
+from functools import partial
+from itertools import chain
 from tftp.datagram import (ACKDatagram, ERRORDatagram, ERR_TID_UNKNOWN,
     TFTPDatagramFactory, split_opcode, OP_OACK, OP_ERROR, OACKDatagram, OP_ACK,
     OP_DATA)
 from tftp.session import WriteSession, MAX_BLOCK_SIZE, ReadSession
-from tftp.util import SequentialCall
+from tftp.util import timedCaller
 from twisted.internet import reactor
+from twisted.internet.defer import succeed
 from twisted.internet.protocol import DatagramProtocol
 from twisted.python import log
 from twisted.python.compat import intToBytes
@@ -57,7 +60,7 @@ class TFTPBootstrap(DatagramProtocol):
             self.options = options
         self.resultant_options = OrderedDict()
         self.remote = remote
-        self.timeout_watchdog = None
+        self.timeout_watchdog = succeed(None)
         self.backend = backend
         if _clock is not None:
             self._clock = _clock
@@ -189,13 +192,16 @@ class TFTPBootstrap(DatagramProtocol):
         log.msg("Got error: %s" % datagram)
         return self.cancel()
 
+    def stopProtocol(self):
+        self.timeout_watchdog.cancel()
+        return super(TFTPBootstrap, self).stopProtocol()
+
     def cancel(self):
         """Terminate this protocol instance. If the underlying
         L{ReadSession}/L{WriteSession} is running, delegate the call to it.
 
         """
-        if self.timeout_watchdog is not None and self.timeout_watchdog.active():
-            self.timeout_watchdog.cancel()
+        self.timeout_watchdog.cancel()
         if self.session.started:
             self.session.cancel()
         else:
@@ -204,7 +210,7 @@ class TFTPBootstrap(DatagramProtocol):
 
     def timedOut(self):
         """This protocol instance has timed out during the initial handshake."""
-        log.msg("Timed during option negotiation process")
+        log.msg("Timed out during option negotiation process")
         self.cancel()
 
 
@@ -220,8 +226,6 @@ class LocalOriginWriteSession(TFTPBootstrap):
     def startProtocol(self):
         """Connect the transport and start the L{timeout_watchdog}"""
         self.transport.connect(*self.remote)
-        if self.timeout_watchdog is not None:
-            self.timeout_watchdog.start()
 
     def tftp_OACK(self, datagram):
         """Handle the OACK datagram
@@ -232,8 +236,7 @@ class LocalOriginWriteSession(TFTPBootstrap):
         """
         if not self.session.started:
             self.resultant_options = self.processOptions(datagram.options)
-            if self.timeout_watchdog.active():
-                self.timeout_watchdog.cancel()
+            self.timeout_watchdog.cancel()
             return self.transport.write(ACKDatagram(0).to_wire())
         else:
             log.msg("Duplicate OACK received, send back ACK and ignore")
@@ -243,8 +246,7 @@ class LocalOriginWriteSession(TFTPBootstrap):
         if datagram.opcode == OP_OACK:
             return self.tftp_OACK(datagram)
         elif datagram.opcode == OP_DATA and datagram.blocknum == 1:
-            if self.timeout_watchdog is not None and self.timeout_watchdog.active():
-                self.timeout_watchdog.cancel()
+            self.timeout_watchdog.cancel()
             if not self.session.started:
                 self.applyOptions(self.session, self.resultant_options)
                 self.session.transport = self.transport
@@ -276,18 +278,13 @@ class RemoteOriginWriteSession(TFTPBootstrap):
             bytes = OACKDatagram(self.resultant_options).to_wire()
         else:
             bytes = ACKDatagram(0).to_wire()
-        self.timeout_watchdog = SequentialCall.run(
-            self.timeout[:-1],
-            callable=self.transport.write, callable_args=[bytes, ],
-            on_timeout=lambda: self._clock.callLater(self.timeout[-1], self.timedOut),
-            run_now=True,
-            _clock=self._clock
-        )
+        self.timeout_watchdog = timedCaller(
+            chain((0,), self.timeout), partial(self.transport.write, bytes),
+            self.timedOut, clock=self._clock)
 
     def _datagramReceived(self, datagram):
         if datagram.opcode == OP_DATA and datagram.blocknum == 1:
-            if self.timeout_watchdog.active():
-                self.timeout_watchdog.cancel()
+            self.timeout_watchdog.cancel()
             if not self.session.started:
                 self.applyOptions(self.session, self.resultant_options)
                 self.session.transport = self.transport
@@ -309,8 +306,6 @@ class LocalOriginReadSession(TFTPBootstrap):
     def startProtocol(self):
         """Connect the transport and start the L{timeout_watchdog}"""
         self.transport.connect(*self.remote)
-        if self.timeout_watchdog is not None:
-            self.timeout_watchdog.start()
 
     def _datagramReceived(self, datagram):
         if datagram.opcode == OP_OACK:
@@ -319,8 +314,7 @@ class LocalOriginReadSession(TFTPBootstrap):
                     and not self.session.started):
             self.session.transport = self.transport
             self.session.startProtocol()
-            if self.timeout_watchdog is not None and self.timeout_watchdog.active():
-                self.timeout_watchdog.cancel()
+            self.timeout_watchdog.cancel()
             return self.session.nextBlock()
         elif self.session.started:
             return self.session.datagramReceived(datagram)
@@ -335,8 +329,7 @@ class LocalOriginReadSession(TFTPBootstrap):
         """
         if not self.session.started:
             self.resultant_options = self.processOptions(datagram.options)
-            if self.timeout_watchdog is not None and self.timeout_watchdog.active():
-                self.timeout_watchdog.cancel()
+            self.timeout_watchdog.cancel()
             self.applyOptions(self.session, self.resultant_options)
             self.session.transport = self.transport
             self.session.startProtocol()
@@ -380,13 +373,9 @@ class RemoteOriginReadSession(TFTPBootstrap):
         if self.options:
             self.resultant_options = self.processOptions(self.options)
             bytes = OACKDatagram(self.resultant_options).to_wire()
-            self.timeout_watchdog = SequentialCall.run(
-                self.timeout[:-1],
-                callable=self.transport.write, callable_args=[bytes, ],
-                on_timeout=lambda: self._clock.callLater(self.timeout[-1], self.timedOut),
-                run_now=True,
-                _clock=self._clock
-            )
+            self.timeout_watchdog = timedCaller(
+                chain((0,), self.timeout), partial(self.transport.write, bytes),
+                self.timedOut, clock=self._clock)
         else:
             self.session.transport = self.transport
             self.session.startProtocol()
@@ -406,8 +395,7 @@ class RemoteOriginReadSession(TFTPBootstrap):
         @type datagram: L{ACKDatagram}
 
         """
-        if self.timeout_watchdog is not None:
-            self.timeout_watchdog.cancel()
+        self.timeout_watchdog.cancel()
         if not self.session.started:
             self.applyOptions(self.session, self.resultant_options)
             self.session.transport = self.transport

--- a/tftp/bootstrap.py
+++ b/tftp/bootstrap.py
@@ -194,7 +194,7 @@ class TFTPBootstrap(DatagramProtocol):
 
     def stopProtocol(self):
         self.timeout_watchdog.cancel()
-        return super(TFTPBootstrap, self).stopProtocol()
+        return DatagramProtocol.stopProtocol(self)
 
     def cancel(self):
         """Terminate this protocol instance. If the underlying

--- a/tftp/test/test_util.py
+++ b/tftp/test/test_util.py
@@ -10,7 +10,7 @@ from twisted.trial import unittest
 class TimedCaller(unittest.TestCase):
 
     @staticmethod
-    def makeTimedCaller(*timings, clock=None):
+    def makeTimedCaller(timings, clock=None):
         record = []
         call = lambda: record.append("call")
         last = lambda: record.append("last")
@@ -22,25 +22,25 @@ class TimedCaller(unittest.TestCase):
 
     @inlineCallbacks
     def test_does_nothing_with_no_timings(self):
-        caller, record = self.makeTimedCaller()
+        caller, record = self.makeTimedCaller([])
         self.assertIs(None, (yield caller))
         self.assertEqual([], record)
 
     @inlineCallbacks
     def test_calls_last_with_one_timing(self):
-        caller, record = self.makeTimedCaller(0)
+        caller, record = self.makeTimedCaller([0])
         self.assertIs(None, (yield caller))
         self.assertEqual(["last"], record)
 
     @inlineCallbacks
     def test_calls_both_functions_with_multiple_timings(self):
-        caller, record = self.makeTimedCaller(0, 0)
+        caller, record = self.makeTimedCaller([0, 0])
         self.assertIs(None, (yield caller))
         self.assertEqual(["call", "last"], record)
 
     def test_pauses_between_calls(self):
         clock = Clock()
-        caller, record = self.makeTimedCaller(1, 2, 3, clock=clock)
+        caller, record = self.makeTimedCaller([1, 2, 3], clock=clock)
         self.assertEqual([], record)
         clock.advance(1)
         self.assertEqual(["call"], record)
@@ -52,7 +52,7 @@ class TimedCaller(unittest.TestCase):
 
     def test_can_be_cancelled(self):
         clock = Clock()
-        caller, record = self.makeTimedCaller(1, 2, 3, clock=clock)
+        caller, record = self.makeTimedCaller([1, 2, 3], clock=clock)
         self.assertEqual([], record)
         clock.advance(1)
         self.assertEqual(["call"], record)

--- a/tftp/test/test_util.py
+++ b/tftp/test/test_util.py
@@ -20,11 +20,9 @@ class TimedCaller(unittest.TestCase):
             caller = timedCaller(timings, call, last, clock)
         return caller, record
 
-    @inlineCallbacks
-    def test_does_nothing_with_no_timings(self):
-        caller, record = self.makeTimedCaller([])
-        self.assertIs(None, (yield caller))
-        self.assertEqual([], record)
+    def test_raises_ValueError_with_no_timings(self):
+        error = self.assertRaises(ValueError, self.makeTimedCaller, [])
+        self.assertEqual("No timings specified.", str(error))
 
     @inlineCallbacks
     def test_calls_last_with_one_timing(self):

--- a/tftp/test/test_util.py
+++ b/tftp/test/test_util.py
@@ -1,68 +1,65 @@
 '''
 @author: shylent
 '''
-from tftp.util import SequentialCall, Spent, Cancelled
+from tftp.util import CANCELLED, timedCaller
+from twisted.internet.defer import inlineCallbacks
 from twisted.internet.task import Clock
 from twisted.trial import unittest
 
 
-class CallCounter(object):
-    call_num = 0
+class TimedCaller(unittest.TestCase):
 
-    def __call__(self):
-        self.call_num += 1
+    @staticmethod
+    def makeTimedCaller(*timings, clock=None):
+        record = []
+        call = lambda: record.append("call")
+        last = lambda: record.append("last")
+        if clock is None:
+            caller = timedCaller(timings, call, last)
+        else:
+            caller = timedCaller(timings, call, last, clock)
+        return caller, record
 
+    @inlineCallbacks
+    def test_does_nothing_with_no_timings(self):
+        caller, record = self.makeTimedCaller()
+        self.assertIs(None, (yield caller))
+        self.assertEqual([], record)
 
-class SequentialCalling(unittest.TestCase):
+    @inlineCallbacks
+    def test_calls_last_with_one_timing(self):
+        caller, record = self.makeTimedCaller(0)
+        self.assertIs(None, (yield caller))
+        self.assertEqual(["last"], record)
 
-    def setUp(self):
-        self.f = CallCounter()
-        self.t = CallCounter()
-        self.clock = Clock()
+    @inlineCallbacks
+    def test_calls_both_functions_with_multiple_timings(self):
+        caller, record = self.makeTimedCaller(0, 0)
+        self.assertIs(None, (yield caller))
+        self.assertEqual(["call", "last"], record)
 
-    def test_empty(self):
-        SequentialCall.run((), self.f, on_timeout=self.t, _clock=self.clock)
-        self.clock.pump((1,))
-        self.assertEqual(self.f.call_num, 0)
-        self.assertEqual(self.t.call_num, 1)
+    def test_pauses_between_calls(self):
+        clock = Clock()
+        caller, record = self.makeTimedCaller(1, 2, 3, clock=clock)
+        self.assertEqual([], record)
+        clock.advance(1)
+        self.assertEqual(["call"], record)
+        clock.advance(2)
+        self.assertEqual(["call", "call"], record)
+        clock.advance(3)
+        self.assertEqual(["call", "call", "last"], record)
+        self.assertIs(None, caller.result)  # Finished.
 
-    def test_empty_now(self):
-        SequentialCall.run((), self.f, on_timeout=self.t, run_now=True, _clock=self.clock)
-        self.clock.pump((1,))
-        self.assertEqual(self.f.call_num, 1)
-        self.assertEqual(self.t.call_num, 1)
-
-    def test_non_empty(self):
-        c = SequentialCall.run((1, 3, 5), self.f, run_now=True, on_timeout=self.t, _clock=self.clock)
-        self.clock.advance(0.1)
-        self.assertTrue(c.active())
-        self.assertEqual(self.f.call_num, 1)
-        self.clock.pump((1,)*2)
-        self.assertTrue(c.active())
-        self.assertEqual(self.f.call_num, 2)
-        self.clock.pump((1,)*3)
-        self.assertTrue(c.active())
-        self.assertEqual(self.f.call_num, 3)
-        self.clock.pump((1,)*5)
-        self.assertFalse(c.active())
-        self.assertEqual(self.f.call_num, 4)
-        self.assertEqual(self.t.call_num, 1)
-        self.assertRaises(Spent, c.reschedule)
-        self.assertRaises(Spent, c.cancel)
-
-    def test_cancel(self):
-        c = SequentialCall.run((1, 3, 5), self.f, on_timeout=self.t, _clock=self.clock)
-        self.clock.pump((1,)*2)
-        self.assertEqual(self.f.call_num, 1)
-        c.cancel()
-        self.assertRaises(Cancelled, c.cancel)
-        self.assertEqual(self.t.call_num, 0)
-        self.assertRaises(Cancelled, c.reschedule)
-
-    def test_cancel_immediately(self):
-        c = SequentialCall.run((1, 3, 5), lambda: c.cancel(), run_now=True,
-                               on_timeout=self.t, _clock=self.clock)
-        self.clock.pump((1,)*2)
-        self.assertRaises(Cancelled, c.cancel)
-        self.assertEqual(self.t.call_num, 0)
-        self.assertRaises(Cancelled, c.reschedule)
+    def test_can_be_cancelled(self):
+        clock = Clock()
+        caller, record = self.makeTimedCaller(1, 2, 3, clock=clock)
+        self.assertEqual([], record)
+        clock.advance(1)
+        self.assertEqual(["call"], record)
+        clock.advance(2)
+        self.assertEqual(["call", "call"], record)
+        caller.cancel()
+        self.assertIs(CANCELLED, caller.result)
+        # Advancing the clock does not result in more calls.
+        clock.advance(3)
+        self.assertEqual(["call", "call"], record)

--- a/tftp/test/test_util.py
+++ b/tftp/test/test_util.py
@@ -1,7 +1,9 @@
 '''
 @author: shylent
 '''
-from tftp.util import CANCELLED, timedCaller
+from itertools import count, islice
+from random import randint
+from tftp.util import CANCELLED, iterlast, timedCaller
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.task import Clock
 from twisted.trial import unittest
@@ -61,3 +63,33 @@ class TimedCaller(unittest.TestCase):
         # Advancing the clock does not result in more calls.
         clock.advance(3)
         self.assertEqual(["call", "call"], record)
+
+
+class IterLast(unittest.TestCase):
+
+    def test_yields_nothing_when_no_input(self):
+        self.assertEqual([], list(iterlast([])))
+
+    def test_yields_once_for_input_of_one(self):
+        thing = object()
+        self.assertEqual(
+            [(True, thing)],
+            list(iterlast([thing])))
+
+    def test_yields_once_for_each_input(self):
+        things = [object() for _ in range(1, randint(9, 99))]
+        self.assertEqual(
+            [(False, thing) for thing in things[:-1]] + [(True, things[-1])],
+            list(iterlast(things)))
+
+    def test_works_with_unsized_iterators(self):
+        things = [object() for _ in range(1, randint(9, 99))]
+        self.assertEqual(
+            [(False, thing) for thing in things[:-1]] + [(True, things[-1])],
+            list(iterlast(iter(things))))
+
+    def test_works_with_infinite_iterators(self):
+        # ... though is_last will never be True.
+        self.assertEqual(
+            [(False, 1), (False, 2), (False, 3)],
+            list(islice(iterlast(count(1)), 3)))

--- a/tftp/util.py
+++ b/tftp/util.py
@@ -4,7 +4,7 @@
 from functools import wraps
 from itertools import tee
 from twisted.internet import reactor
-from twisted.internet.defer import CancelledError, maybeDeferred, succeed
+from twisted.internet.defer import CancelledError, maybeDeferred
 from twisted.internet.task import deferLater
 
 
@@ -30,6 +30,9 @@ def timedCaller(timings, call, last, clock=reactor):
     successful -- i.e. there is something to cancel -- then the result is set
     to L{CANCELLED}. In other words, L{CancelledError} is squashed into a
     non-failure condition.
+
+    @raise ValueError: if no timings are specified; there must be at least
+        one, even if specifies a zero seconds delay.
     """
     timings = iterlast(timings)
 
@@ -41,8 +44,7 @@ def timedCaller(timings, call, last, clock=reactor):
             else:
                 return deferLater(clock, delay, call).addCallback(iterate)
         else:
-            # No timings were given.
-            return succeed(None)
+            raise ValueError("No timings specified.")
 
     def squashCancelled(failure):
         if failure.check(CancelledError) is None:

--- a/tftp/util.py
+++ b/tftp/util.py
@@ -27,8 +27,8 @@ def timedCaller(timings, call, last, clock=reactor):
     infinite iterable then C{last} will never be called.
 
     This returns a C{Deferred} which can be cancelled. If the cancellation is
-    successful — i.e. there is something to cancel — then the result is set to
-    L{CANCELLED}. In other words, L{CancelledError} is squashed into a
+    successful -- i.e. there is something to cancel -- then the result is set
+    to L{CANCELLED}. In other words, L{CancelledError} is squashed into a
     non-failure condition.
     """
     timings = iterlast(timings)

--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,6 @@
 envlist = py27, py34, py35
 
 [testenv]
-commands = {envbindir}/trial tftp
+commands = python setup.py test {posargs}
+deps = setuptools_trial
+sitepackages = False


### PR DESCRIPTION
Fixes #29 and #30.

I tried to do this with `SequentialCall` but it's behaviour just didn't match what I was trying to achieve — cancelling wouldn't cancel the last call — and I realised I could do it in a simpler way, hence the new `timedCaller` function.

This also changes tests to run with [`setuptools_trial`](https://pypi.python.org/pypi/setuptools_trial). Tests were not running correctly via `tox` and I was at a loss to explain why. Using `setuptools_trial` fixes this and also allows the use of `python setup.py test` — an increasingly common pattern — to run tests with `trial`.